### PR TITLE
 (#13) Check for state before powering off

### DIFF
--- a/lib/vagrant-vbox-snapshot/commands/back.rb
+++ b/lib/vagrant-vbox-snapshot/commands/back.rb
@@ -16,8 +16,11 @@ module VagrantPlugins
 
           with_target_vms(argv, single_target: true) do |machine|
             vm_id = machine.id
+            vm_info = `VBoxManage showvminfo #{vm_id} --machinereadable`
+            vm_state = vm_info.match(/^VMState="([a-z]+)".*/)[1]
+
             system "VBoxManage snapshot #{vm_id} list --details"
-            system "VBoxManage controlvm #{vm_id} poweroff"
+            system "VBoxManage controlvm #{vm_id} poweroff" if vm_state != 'poweroff'
             system "VBoxManage snapshot  #{vm_id} restorecurrent"
             system "VBoxManage startvm   #{vm_id} --type headless"
           end

--- a/lib/vagrant-vbox-snapshot/commands/go.rb
+++ b/lib/vagrant-vbox-snapshot/commands/go.rb
@@ -57,7 +57,10 @@ module VagrantPlugins
 
             before_restore(vm_id)
 
-            system "VBoxManage controlvm #{vm_id} poweroff"
+            vm_info = `VBoxManage showvminfo #{vm_id} --machinereadable`
+            vm_state = vm_info.match(/^VMState="([a-z]+)".*/)[1]
+
+            system "VBoxManage controlvm #{vm_id} poweroff" if vm_state != 'poweroff'
             system "VBoxManage snapshot #{vm_id} restore #{snapshot_name}"
 
             if options[:reload]


### PR DESCRIPTION
 This commit adds a check when powering off the VM prior to restoring a
 snapshot. Without this commit, the plugin will attempt to power off
 already halted machines, resulting in a failure.
