### PR TITLE
added method synopsis to Root class

### DIFF
--- a/lib/vagrant-vbox-snapshot/commands/root.rb
+++ b/lib/vagrant-vbox-snapshot/commands/root.rb
@@ -2,6 +2,10 @@ module VagrantPlugins
   module VBoxSnapshot
     module Command
       class Root < Vagrant.plugin(2, :command)
+        def self.synopsis
+          "manages snapshots of the machine: taking, restoring, deleting, etc."
+        end
+
         def initialize(argv, env)
           super 
 


### PR DESCRIPTION
When running vagrant without commands there is a listing of all
available commands with a short description. Because of the missing
method synopsis in class Root the description is missing at the
moment for the vbox-snapshot plugin.
