### PR TITLE
vagrant snapshot go and vagrant snapshot back no longer fail if the VM is in "saved" state

### DIFF
--- a/lib/vagrant-vbox-snapshot/commands/back.rb
+++ b/lib/vagrant-vbox-snapshot/commands/back.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
           with_target_vms(argv, single_target: true) do |machine|
             check_runnable_on(machine)
 
-            if machine.state.id != :poweroff
+            if machine.state.id != :poweroff and machine.state.id != :saved
               machine.provider.driver.execute("controlvm", machine.id, "poweroff")
             end
 

--- a/lib/vagrant-vbox-snapshot/commands/go.rb
+++ b/lib/vagrant-vbox-snapshot/commands/go.rb
@@ -59,7 +59,7 @@ module VagrantPlugins
 
             before_restore(machine)
 
-            if machine.state.id != :poweroff
+            if machine.state.id != :poweroff and machine.state.id != :saved
               @env.ui.info("Powering off machine #{vm_id}")
               machine.provider.driver.execute("controlvm", machine.id, "poweroff")
             end


### PR DESCRIPTION
This has annoyed me for quite some time, since I sometimes go to a snapshot via the gui, delete a bunch of snapshots and then run a script that uses vagrant snapshot go.