### PR TITLE
Add 'restore' as an alias for 'go'

### DIFF
--- a/lib/vagrant-vbox-snapshot/commands/go.rb
+++ b/lib/vagrant-vbox-snapshot/commands/go.rb
@@ -37,9 +37,9 @@ module VagrantPlugins
           options[:reload] = false
 
           opts = OptionParser.new do |opts|
-            opts.banner = "Go to specified snapshot"
+            opts.banner = "Restore (aka. go to) specified snapshot"
             opts.separator ""
-            opts.separator "Usage: vagrant snapshot go [vm-name] <SNAPSHOT_NAME>"
+            opts.separator "Usage: vagrant snapshot restore|go [vm-name] <SNAPSHOT_NAME>"
 
             opts.on("-r", "--reload", "Runs 'vagrant reload --no-provision' after restoring snapshot to ensure Vagrantfile config is applied.") do |reload|
               options[:reload] = reload

--- a/lib/vagrant-vbox-snapshot/commands/root.rb
+++ b/lib/vagrant-vbox-snapshot/commands/root.rb
@@ -24,6 +24,10 @@ module VagrantPlugins
             require_relative('go')
             Go
           end
+          @subcommands.register(:restore) do
+            require_relative('go')
+            Go
+          end
           @subcommands.register(:back) do
             require_relative('back')
             Back


### PR DESCRIPTION
Vbox talks about "restoring" snapshots, so I think this tool should accept "vagrant snapshot restore ..."