### PR TITLE
vagrant snapshot go and vagrant snapshot back no longer fail if the VM is in "aborted" state

### DIFF
--- a/lib/vagrant-vbox-snapshot/commands/back.rb
+++ b/lib/vagrant-vbox-snapshot/commands/back.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
           with_target_vms(argv, single_target: true) do |machine|
             check_runnable_on(machine)
 
-            if machine.state.id != :poweroff and machine.state.id != :saved
+            if machine.state.id != :poweroff and machine.state.id != :saved and machine.state.id != :aborted
               machine.provider.driver.execute("controlvm", machine.id, "poweroff")
             end
 

--- a/lib/vagrant-vbox-snapshot/commands/go.rb
+++ b/lib/vagrant-vbox-snapshot/commands/go.rb
@@ -59,7 +59,7 @@ module VagrantPlugins
 
             before_restore(machine)
 
-            if machine.state.id != :poweroff and machine.state.id != :saved
+            if machine.state.id != :poweroff and machine.state.id != :saved and machine.state.id != :aborted
               @env.ui.info("Powering off machine #{vm_id}")
               machine.provider.driver.execute("controlvm", machine.id, "poweroff")
             end


### PR DESCRIPTION
This just happened to me in a Jenkins Build.
You don't want to ssh into your Jenkins slaves :)

<sub>I didn't test this, but at worst, it'll behave as before :)</sub>
